### PR TITLE
6 add goerli support to app chains config

### DIFF
--- a/components/AppWrapper.tsx
+++ b/components/AppWrapper.tsx
@@ -5,7 +5,7 @@ import { publicProvider } from 'wagmi/providers/public'
 import { SWRConfig } from 'swr'
 import '@rainbow-me/rainbowkit/styles.css';
 
-const { chains, provider } = configureChains([chain.mainnet], [publicProvider()])
+const { chains, provider } = configureChains([chain.mainnet, chain.goerli], [publicProvider()])
 const { connectors } = getDefaultWallets({
   appName: 'BlockSyncer',
   chains,

--- a/components/AppWrapper.tsx
+++ b/components/AppWrapper.tsx
@@ -7,7 +7,7 @@ import '@rainbow-me/rainbowkit/styles.css';
 
 const { chains, provider } = configureChains([chain.mainnet, chain.goerli], [publicProvider()])
 const { connectors } = getDefaultWallets({
-  appName: 'BlockSyncer',
+  appName: 'NeoSound',
   chains,
 })
 

--- a/components/ConnectButton.tsx
+++ b/components/ConnectButton.tsx
@@ -13,11 +13,14 @@ export function ConnectButton({ ...props }) {
             <>
               {(() => {
                 if (!mounted || !account || !chain) {
-                  return <button onClick={openConnectModal}>Connect Wallet</button>
+                  return <button onClick={openConnectModal} className="text-sm">Connect Wallet</button>
+                }
+                if (chain.unsupported) {
+                  return <div className="text-red-400 text-sm">&nbsp;&#x26A0; Wrong Network</div>
                 }
                 return (
                   <button onClick={openAccountModal}>
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 text-sm">
                       <Avatar />
                       {account.displayName}
                     </div>

--- a/components/ConnectButton.tsx
+++ b/components/ConnectButton.tsx
@@ -4,7 +4,7 @@ import { Avatar } from './elements/Avatar'
 export function ConnectButton({ ...props }) {
   return (
     <div
-      className="connect-button-wrapper relative flex items-center pr-3 pl-1.5 py-1.5 rounded-2xl bg-slate-100 overflow-hidden"
+      className="connect-button-wrapper relative flex items-center pr-3 pl-3 py-1.5 rounded-2xl bg-slate-100 overflow-hidden"
       {...props}
     >
       <RKConnectButton.Custom>
@@ -16,7 +16,7 @@ export function ConnectButton({ ...props }) {
                   return <button onClick={openConnectModal} className="text-sm">Connect Wallet</button>
                 }
                 if (chain.unsupported) {
-                  return <div className="text-red-400 text-sm">&nbsp;&#x26A0; Wrong Network</div>
+                  return <div className="text-red-400 text-sm">&#x26A0; Wrong Network</div>
                 }
                 return (
                   <button onClick={openAccountModal}>

--- a/components/elements/Avatar.tsx
+++ b/components/elements/Avatar.tsx
@@ -7,6 +7,9 @@ import { useAuth } from "hooks/useAuth"
 
 export function Avatar() {
   const { ensName, ensAvatar } = useAuth()
+
+  if (!ensAvatar) return null
+
   return (
     <div className="relative overflow-hidden w-8 h-8 rounded-full">
       {ensAvatar


### PR DESCRIPTION
This pull request addresses:
https://github.com/public-assembly/neosound-sandbox/issues/6

- The app now supports goerli testnet
- Also adjusted the connect wallet component to indicate if user is connected to unsupported network
- Did some minor styling tweaks and the avatar component in the connected state only renders if there is an image available

(print error if user connected to unsupported network)
<img width="1440" alt="Screen Shot 2022-09-23 at 11 16 28 AM" src="https://user-images.githubusercontent.com/7268786/191998233-c7eeee0c-7c3f-44c7-b30f-1e9e4e50dc50.png">

(just to display user connected to goerli)
<img width="1434" alt="Screen Shot 2022-09-23 at 9 26 45 AM" src="https://user-images.githubusercontent.com/7268786/191998282-97929d03-5a39-4ee5-8682-7f5c7b8cc3e6.png">

Side note: might be nice to have a little indicator somewhere in the UI that shows what network user is currently connected to. @0xTranqui @losingmyego 

